### PR TITLE
Include idea.vmoptions for JVM options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,24 @@ wget --no-check-certificate -O ~/Library/Preferences/RubyMineXX/keymaps/pivotal.
 
 If RubyMine is running you will need to restart before the keybindings will be available.
 
+Pivotal Standard RubyMine JVM Options
+-------------------------------------
+
+These are the JVM options that we find to work well for the kinds of projects we develop on modern iMacs.
+To install these options into RubyMine copy the idea.vmoptions file to this path:
+
+~~~
+~/Library/Preferences/RubyMineXX/
+~~~
+
+...or you can just run the following command:
+
+~~~
+wget --no-check-certificate -O ~/Library/Preferences/RubyMineXX/idea.vmoptions http://github.com/pivotal/Pivotal-Preferences-RubyMine/raw/master/preferences/idea.vmoptions
+~~~
+
+If RubyMine is running you will need to restart before the preferences will take effect.
+
 
 RubyMine Live Templates for working with Ruby
 ---------------------------------------------

--- a/preferences/idea.vmoptions
+++ b/preferences/idea.vmoptions
@@ -1,0 +1,6 @@
+-Xms128m
+-Xmx1024m
+-XX:MaxPermSize=250m
+-XX:ReservedCodeCacheSize=64m
+-XX:+UseCodeCacheFlushing
+-XX:+UseCompressedOops


### PR DESCRIPTION
This stops Rubymine 5.0 from hanging when opening large projects.
