### PR TITLE
Moves tab management keystrokes from magic to smash keys

### DIFF
--- a/keymaps/Pivotal.xml
+++ b/keymaps/Pivotal.xml
@@ -229,8 +229,8 @@
     <keyboard-shortcut first-keystroke="alt UP" />
   </action>
   <action id="MoveEditorToOppositeTabGroup">
-    <keyboard-shortcut first-keystroke="control meta alt RIGHT" />
-    <keyboard-shortcut first-keystroke="control meta alt LEFT" />
+    <keyboard-shortcut first-keystroke="shift control meta alt RIGHT" />
+    <keyboard-shortcut first-keystroke="shift control meta alt LEFT" />
   </action>
   <action id="MoveStatementDown">
     <keyboard-shortcut first-keystroke="shift control DOWN" />
@@ -297,10 +297,10 @@
     <keyboard-shortcut first-keystroke="shift control F10" />
   </action>
   <action id="SplitHorizontally">
-    <keyboard-shortcut first-keystroke="control meta alt DOWN" />
+    <keyboard-shortcut first-keystroke="shift control meta alt DOWN" />
   </action>
   <action id="SplitVertically">
-    <keyboard-shortcut first-keystroke="control meta alt UP" />
+    <keyboard-shortcut first-keystroke="shift control meta alt UP" />
   </action>
   <action id="StepInto">
     <keyboard-shortcut first-keystroke="alt F9" />


### PR DESCRIPTION
The [magic] + [arrow keys] are used by most window management utilities most notably 'ShiftIt' and are in direct conflict with the current RM tab management key bindings.   This commit moves those bindings to be [smash] + [arrow keys] which does not have any known conflicts with anything allowing developer to be able to manage RM tabs using keybindings again.

Glossary:
magic = [ctrl] + [option] + [cmd]
smash = [magic] + [shift]
