### PR TITLE
Moves [cmd] + [shft] + O to be used for open quickly dialog

### DIFF
--- a/keymaps/Pivotal.xml
+++ b/keymaps/Pivotal.xml
@@ -201,6 +201,7 @@
   <action id="GotoFile">
     <keyboard-shortcut first-keystroke="shift control N" />
     <keyboard-shortcut first-keystroke="shift meta N" />
+    <keyboard-shortcut first-keystroke="shift meta O" />
   </action>
   <action id="GotoLine">
     <keyboard-shortcut first-keystroke="meta L" />
@@ -252,9 +253,7 @@
     <keyboard-shortcut first-keystroke="shift meta CLOSE_BRACKET" />
     <keyboard-shortcut first-keystroke="meta alt RIGHT" />
   </action>
-  <action id="OpenDirectoryProject">
-    <keyboard-shortcut first-keystroke="shift meta O" />
-  </action>
+  <action id="OpenDirectoryProject" />
   <action id="OpenFile">
     <keyboard-shortcut first-keystroke="meta O" />
   </action>


### PR DESCRIPTION
This moves the keybinding back to RM default key bindings and is more in sync with OSX general preferences for quick open.  It was previously bound to open project which is such a rare thing to need to do that it does not need it's own key binding.
