### PR TITLE
Adds keycaps for Splitting windows

### DIFF
--- a/RubyMineXX/keymaps/Pivotal OS X 10_5_.xml
+++ b/RubyMineXX/keymaps/Pivotal OS X 10_5_.xml
@@ -7,13 +7,14 @@
     <keyboard-shortcut first-keystroke="control meta alt R" />
   </action>
   <action id="MoveEditorToOppositeTabGroup">
-    <keyboard-shortcut first-keystroke="control meta M" />
+    <keyboard-shortcut first-keystroke="shift control meta alt LEFT" />
+    <keyboard-shortcut first-keystroke="shift control meta alt RIGHT" />
   </action>
   <action id="SplitHorizontally">
-    <keyboard-shortcut first-keystroke="shift control S" />
+    <keyboard-shortcut first-keystroke="shift control meta alt DOWN" />
   </action>
   <action id="SplitVertically">
-    <keyboard-shortcut first-keystroke="control S" />
+    <keyboard-shortcut first-keystroke="shift control meta alt UP" />
   </action>
 </keymap>
 


### PR DESCRIPTION
These are the settings from the old key mapping.  it is similar to the shift-it keybindings with the addition of the shift key.

**smash + up** for split vertically
**smash + down** for split horizontally
**smash + left/right** for move to opposite tab group
where _smash_ = **Cmd + Opt +Ctrl + Shift**

I don't think we should bind ctrl+s to anything but save as Windows and other os's consider that to be the save key, it's kind of like binding ctrl+q or w where the key already contains a lot of meaning.
