### PR TITLE
Add shortcuts for moving a tab

### DIFF
--- a/RubyMineXX/keymaps/Pivotal OS X 10_5_.xml
+++ b/RubyMineXX/keymaps/Pivotal OS X 10_5_.xml
@@ -10,6 +10,12 @@
     <keyboard-shortcut first-keystroke="shift control meta alt LEFT" />
     <keyboard-shortcut first-keystroke="shift control meta alt RIGHT" />
   </action>
+  <action id="MoveTabDown">
+    <keyboard-shortcut first-keystroke="control meta alt DOWN" />
+  </action>
+  <action id="MoveTabRight">
+    <keyboard-shortcut first-keystroke="control meta alt RIGHT" />
+  </action>
   <action id="SplitHorizontally">
     <keyboard-shortcut first-keystroke="shift control meta alt DOWN" />
   </action>


### PR DESCRIPTION
A common workflow is to start working inside a spec file then open the
corresponding implementation file in another tab. Many developers prefer
to have two panes, one for the spec and the other for the implementation
file. 

Adding these shortcuts allows a user to quickly open another
and then quickly move it to another pane via `cmd+opt+ctrl right/down`
